### PR TITLE
Layers support

### DIFF
--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -206,50 +206,30 @@ class fault_injection:
         return self.CORRUPTED_MODEL
 
     def assert_inj_bounds(self, **kwargs):
-        if type(self.CORRUPT_LAYER) == list:
-            index = kwargs.get("index", -1)
-            assert (
-                self.CORRUPT_LAYER[index] >= 0
-                and self.CORRUPT_LAYER[index] < self.get_total_layers()
-            ), "Invalid convolution!"
-            assert (
-                self.CORRUPT_BATCH[index] >= 0
-                and self.CORRUPT_BATCH[index] < self._BATCH_SIZE
-            ), "Invalid batch!"
-            assert (
-                self.CORRUPT_C[index] >= 0
-                and self.CORRUPT_C[index]
-                < self.OUTPUT_SIZE[self.CORRUPT_LAYER[index]][1]
-            ), "Invalid C!"
-            assert (
-                self.CORRUPT_H[index] >= 0
-                and self.CORRUPT_H[index]
-                < self.OUTPUT_SIZE[self.CORRUPT_LAYER[index]][2]
-            ), "Invalid H!"
-            assert (
-                self.CORRUPT_W[index] >= 0
-                and self.CORRUPT_W[index]
-                < self.OUTPUT_SIZE[self.CORRUPT_LAYER[index]][3]
-            ), "Invalid W!"
-        else:
-            assert (
-                self.CORRUPT_LAYER >= 0 and self.CORRUPT_LAYER < self.get_total_layers()
-            ), "Invalid convolution!"
-            assert (
-                self.CORRUPT_BATCH >= 0 and self.CORRUPT_BATCH < self._BATCH_SIZE
-            ), "Invalid batch!"
-            assert (
-                self.CORRUPT_C >= 0
-                and self.CORRUPT_C < self.OUTPUT_SIZE[self.CORRUPT_LAYER][1]
-            ), "Invalid C!"
-            assert (
-                self.CORRUPT_H >= 0
-                and self.CORRUPT_H < self.OUTPUT_SIZE[self.CORRUPT_LAYER][2]
-            ), "Invalid H!"
-            assert (
-                self.CORRUPT_W >= 0
-                and self.CORRUPT_W < self.OUTPUT_SIZE[self.CORRUPT_LAYER][3]
-            ), "Invalid W!"
+        index = kwargs.get("index", -1)
+        assert (
+            self.CORRUPT_LAYER[index] >= 0
+            and self.CORRUPT_LAYER[index] < self.get_total_layers()
+        ), "Invalid convolution!"
+        assert (
+            self.CORRUPT_BATCH[index] >= 0
+            and self.CORRUPT_BATCH[index] < self._BATCH_SIZE
+        ), "Invalid batch!"
+        assert (
+            self.CORRUPT_C[index] >= 0
+            and self.CORRUPT_C[index]
+            < self.OUTPUT_SIZE[self.CORRUPT_LAYER[index]][1]
+        ), "Invalid C!"
+        assert (
+            self.CORRUPT_H[index] >= 0
+            and self.CORRUPT_H[index]
+            < self.OUTPUT_SIZE[self.CORRUPT_LAYER[index]][2]
+        ), "Invalid H!"
+        assert (
+            self.CORRUPT_W[index] >= 0
+            and self.CORRUPT_W[index]
+            < self.OUTPUT_SIZE[self.CORRUPT_LAYER[index]][3]
+        ), "Invalid W!"
 
     def _set_value(self, module, input, output):
         inj_list = list(

--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -208,7 +208,7 @@ class fault_injection:
             index = kwargs.get("index", -1)
             assert (
                 self.CORRUPT_CONV[index] >= 0
-                and self.CORRUPT_CONV[index] < self.get_total_conv()
+                and self.CORRUPT_CONV[index] < self.get_total_layers()
             ), "Invalid convolution!"
             assert (
                 self.CORRUPT_BATCH[index] >= 0
@@ -231,7 +231,7 @@ class fault_injection:
             ), "Invalid W!"
         else:
             assert (
-                self.CORRUPT_CONV >= 0 and self.CORRUPT_CONV < self.get_total_conv()
+                self.CORRUPT_CONV >= 0 and self.CORRUPT_CONV < self.get_total_layers()
             ), "Invalid convolution!"
             assert (
                 self.CORRUPT_BATCH >= 0 and self.CORRUPT_BATCH < self._BATCH_SIZE
@@ -331,7 +331,7 @@ class fault_injection:
     def get_total_batches(self):
         return self._BATCH_SIZE
 
-    def get_total_conv(self):
+    def get_total_layers(self):
         return len(self.OUTPUT_SIZE)
 
     def get_fmaps_num(self, layer):

--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -28,6 +28,8 @@ class fault_injection:
 
         self.CURR_LAYER = 0
         self.OUTPUT_SIZE = []
+        self.LAYER_TYPE = []
+        self.LAYER_DIM = []
         self.HANDLES = []
 
         self.imageC = kwargs.get("c", 3)
@@ -39,10 +41,10 @@ class fault_injection:
 
         self.ORIG_MODEL = model
         self._BATCH_SIZE = batch_size
-        self._LAYER_TYPES = layer_types
+        self._INJ_LAYER_TYPES = layer_types
 
         handles, shapes = self._traverseModelAndSetHooks(
-            self.ORIG_MODEL, self._LAYER_TYPES
+            self.ORIG_MODEL, self._INJ_LAYER_TYPES
         )
 
         b = 1  # profiling only needs one batch element
@@ -103,7 +105,7 @@ class fault_injection:
             self.CORRUPT_H,
             self.CORRUPT_W,
             self.CORRUPT_VALUE,
-            self._LAYER_TYPES,
+            self._INJ_LAYER_TYPES,
         ) = (0, -1, -1, -1, -1, -1, None, [nn.Conv2d])
 
         for i in range(len(self.HANDLES)):
@@ -299,7 +301,12 @@ class fault_injection:
         self.updateConv()
 
     def _save_output_size(self, module, input, output):
-        self.OUTPUT_SIZE.append(list(output.size()))
+        shape = list(output.size())
+        dim = len(shape)
+
+        self.LAYER_TYPE.append(module)
+        self.LAYER_DIM.append(dim)
+        self.OUTPUT_SIZE.append(shape)
 
     def get_original_model(self):
         return self.ORIG_MODEL
@@ -311,7 +318,7 @@ class fault_injection:
         return self.OUTPUT_SIZE
 
     def get_layer_types(self):
-        return self._LAYER_TYPES
+        return self._INJ_LAYER_TYPES
 
     def updateConv(self, value=1):
         self.CURR_LAYER += value

--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -117,13 +117,13 @@ class fault_injection:
         if kwargs:
             if "function" in kwargs:
                 CUSTOM_INJECTION, CUSTOM_FUNCTION = True, kwargs.get("function")
-                corrupt_layer = kwargs.get("conv_num", -1)
+                corrupt_layer = kwargs.get("layer_num", -1)
                 corrupt_k = kwargs.get("k", -1)
                 corrupt_c = kwargs.get("c", -1)
                 corrupt_kH = kwargs.get("h", -1)
                 corrupt_kW = kwargs.get("w", -1)
             else:
-                corrupt_layer = kwargs.get("conv_num", -1)
+                corrupt_layer = kwargs.get("layer_num", -1)
                 corrupt_k = kwargs.get("k", -1)
                 corrupt_c = kwargs.get("c", -1)
                 corrupt_kH = kwargs.get("h", -1)
@@ -166,13 +166,13 @@ class fault_injection:
         if kwargs:
             if "function" in kwargs:
                 CUSTOM_INJECTION, INJECTION_FUNCTION = True, kwargs.get("function")
-                self.CORRUPT_CONV = kwargs.get("conv_num", -1)
+                self.CORRUPT_CONV = kwargs.get("layer_num", -1)
                 self.CORRUPT_BATCH = kwargs.get("batch", -1)
                 self.CORRUPT_C = kwargs.get("c", -1)
                 self.CORRUPT_H = kwargs.get("h", -1)
                 self.CORRUPT_W = kwargs.get("w", -1)
             else:
-                self.CORRUPT_CONV = kwargs.get("conv_num", -1)
+                self.CORRUPT_CONV = kwargs.get("layer_num", -1)
                 self.CORRUPT_BATCH = kwargs.get("batch", -1)
                 self.CORRUPT_C = kwargs.get("c", -1)
                 self.CORRUPT_H = kwargs.get("h", -1)
@@ -253,7 +253,7 @@ class fault_injection:
         if type(self.CORRUPT_CONV) == list:
             inj_list = list(
                 filter(
-                    lambda x: self.CORRUPT_CONV[x] == self.get_curr_conv(),
+                    lambda x: self.CORRUPT_CONV[x] == self.get_curr_layer(),
                     range(len(self.CORRUPT_CONV)),
                 )
             )
@@ -278,7 +278,7 @@ class fault_injection:
 
         else:
             self.assert_inj_bounds()
-            if self.get_curr_conv() == self.CORRUPT_CONV:
+            if self.get_curr_layer() == self.CORRUPT_CONV:
                 logging.info(
                     "Original value at [%d][%d][%d][%d]: %d"
                     % (
@@ -316,16 +316,16 @@ class fault_injection:
     def updateConv(self, value=1):
         self.CURRENT_CONV += value
 
-    def reset_curr_conv(self):
+    def reset_curr_layer(self):
         self.CURRENT_CONV = 0
 
-    def set_corrupt_conv(self, value):
+    def set_corrupt_layer(self, value):
         self.CORRUPT_CONV = value
 
-    def get_curr_conv(self):
+    def get_curr_layer(self):
         return self.CURRENT_CONV
 
-    def get_corrupt_conv(self):
+    def get_corrupt_layer(self):
         return self.CORRUPT_CONV
 
     def get_total_batches(self):

--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -252,51 +252,30 @@ class fault_injection:
             ), "Invalid W!"
 
     def _set_value(self, module, input, output):
-        if type(self.CORRUPT_LAYER) == list:
-            inj_list = list(
-                filter(
-                    lambda x: self.CORRUPT_LAYER[x] == self.get_curr_layer(),
-                    range(len(self.CORRUPT_LAYER)),
+        inj_list = list(
+            filter(
+                lambda x: self.CORRUPT_LAYER[x] == self.get_curr_layer(),
+                range(len(self.CORRUPT_LAYER)),
+            )
+        )
+        for i in inj_list:
+            self.assert_inj_bounds(index=i)
+            logging.info(
+                "Original value at [%d][%d][%d][%d]: %d"
+                % (
+                    self.CORRUPT_BATCH[i],
+                    self.CORRUPT_C[i],
+                    self.CORRUPT_H[i],
+                    self.CORRUPT_W[i],
+                    output[self.CORRUPT_BATCH[i]][self.CORRUPT_C[i]][
+                        self.CORRUPT_H[i]
+                    ][self.CORRUPT_W[i]],
                 )
             )
-            for i in inj_list:
-                self.assert_inj_bounds(index=i)
-                logging.info(
-                    "Original value at [%d][%d][%d][%d]: %d"
-                    % (
-                        self.CORRUPT_BATCH[i],
-                        self.CORRUPT_C[i],
-                        self.CORRUPT_H[i],
-                        self.CORRUPT_W[i],
-                        output[self.CORRUPT_BATCH[i]][self.CORRUPT_C[i]][
-                            self.CORRUPT_H[i]
-                        ][self.CORRUPT_W[i]],
-                    )
-                )
-                logging.info("Changing value to %d" % self.CORRUPT_VALUE[i])
-                output[self.CORRUPT_BATCH[i]][self.CORRUPT_C[i]][self.CORRUPT_H[i]][
-                    self.CORRUPT_W[i]
-                ] = self.CORRUPT_VALUE[i]
-
-        else:
-            self.assert_inj_bounds()
-            if self.get_curr_layer() == self.CORRUPT_LAYER:
-                logging.info(
-                    "Original value at [%d][%d][%d][%d]: %d"
-                    % (
-                        self.CORRUPT_BATCH,
-                        self.CORRUPT_C,
-                        self.CORRUPT_H,
-                        self.CORRUPT_W,
-                        output[self.CORRUPT_BATCH][self.CORRUPT_C][self.CORRUPT_H][
-                            self.CORRUPT_W
-                        ],
-                    )
-                )
-                logging.info("Changing value to %d" % self.CORRUPT_VALUE)
-                output[self.CORRUPT_BATCH][self.CORRUPT_C][self.CORRUPT_H][
-                    self.CORRUPT_W
-                ] = self.CORRUPT_VALUE
+            logging.info("Changing value to %d" % self.CORRUPT_VALUE[i])
+            output[self.CORRUPT_BATCH[i]][self.CORRUPT_C[i]][self.CORRUPT_H[i]][
+                self.CORRUPT_W[i]
+            ] = self.CORRUPT_VALUE[i]
 
         self.updateConv()
 

--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -69,6 +69,26 @@ class fault_injection:
             )
         )
 
+    def fi_reset(self):
+        self._fi_state_reset()
+        self.CORRUPTED_MODEL = None
+        logging.info("Reset fault injector")
+
+    def _fi_state_reset(self):
+        (
+            self.CURR_LAYER,
+            self.CORRUPT_BATCH,
+            self.CORRUPT_LAYER,
+            self.CORRUPT_C,
+            self.CORRUPT_H,
+            self.CORRUPT_W,
+            self.CORRUPT_VALUE,
+            self._INJ_LAYER_TYPES,
+        ) = (0, -1, -1, -1, -1, -1, None, [nn.Conv2d])
+
+        for i in range(len(self.HANDLES)):
+            self.HANDLES[i].remove()
+
     def _traverseModelAndSetHooks(self, model, layer_types):
         handles = []
         shape = []
@@ -90,26 +110,6 @@ class fault_injection:
                     shape.append(i)
 
         return (handles, shape)
-
-    def fi_reset(self):
-        self._fi_state_reset()
-        self.CORRUPTED_MODEL = None
-        logging.info("Reset fault injector")
-
-    def _fi_state_reset(self):
-        (
-            self.CURR_LAYER,
-            self.CORRUPT_BATCH,
-            self.CORRUPT_LAYER,
-            self.CORRUPT_C,
-            self.CORRUPT_H,
-            self.CORRUPT_W,
-            self.CORRUPT_VALUE,
-            self._INJ_LAYER_TYPES,
-        ) = (0, -1, -1, -1, -1, -1, None, [nn.Conv2d])
-
-        for i in range(len(self.HANDLES)):
-            self.HANDLES[i].remove()
 
     def declare_weight_fi(self, **kwargs):
         self._fi_state_reset()

--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -28,8 +28,8 @@ class fault_injection:
 
         self.CURR_LAYER = 0
         self.OUTPUT_SIZE = []
-        self.LAYER_TYPE = []
-        self.LAYER_DIM = []
+        self.LAYERS_TYPE = []
+        self.LAYERS_DIM = []
         self.HANDLES = []
 
         self.imageC = kwargs.get("c", 3)
@@ -304,8 +304,8 @@ class fault_injection:
         shape = list(output.size())
         dim = len(shape)
 
-        self.LAYER_TYPE.append(module)
-        self.LAYER_DIM.append(dim)
+        self.LAYERS_TYPE.append(type(module))
+        self.LAYERS_DIM.append(dim)
         self.OUTPUT_SIZE.append(shape)
 
     def get_original_model(self):
@@ -317,7 +317,13 @@ class fault_injection:
     def get_output_size(self):
         return self.OUTPUT_SIZE
 
-    def get_layer_types(self):
+    def get_layer_type(self, layer_num):
+        return self.LAYERS_TYPE[layer_num]
+
+    def get_layer_dim(self, layer_num):
+        return self.LAYERS_DIM[layer_num]
+
+    def get_inj_layer_types(self):
         return self._INJ_LAYER_TYPES
 
     def updateConv(self, value=1):

--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -19,12 +19,12 @@ class fault_injection:
         self.CUSTOM_INJECTION = False
         self.INJECTION_FUNCTION = None
 
-        self.CORRUPT_BATCH = -1
-        self.CORRUPT_LAYER = -1
-        self.CORRUPT_C = -1
-        self.CORRUPT_H = -1
-        self.CORRUPT_W = -1
-        self.CORRUPT_VALUE = None
+        self.CORRUPT_BATCH = list()
+        self.CORRUPT_LAYER = list()
+        self.CORRUPT_DIM1 = list()  # C
+        self.CORRUPT_DIM2 = list()  # H
+        self.CORRUPT_DIM3 = list()  # W
+        self.CORRUPT_VALUE = list()
 
         self.CURR_LAYER = 0
         self.OUTPUT_SIZE = []
@@ -84,7 +84,7 @@ class fault_injection:
             self.CORRUPT_W,
             self.CORRUPT_VALUE,
             self._INJ_LAYER_TYPES,
-        ) = (0, -1, -1, -1, -1, -1, None, [nn.Conv2d])
+        ) = (0, list(), list(), list(), list(), list(), list(), [nn.Conv2d])
 
         for i in range(len(self.HANDLES)):
             self.HANDLES[i].remove()
@@ -119,18 +119,18 @@ class fault_injection:
         if kwargs:
             if "function" in kwargs:
                 CUSTOM_INJECTION, CUSTOM_FUNCTION = True, kwargs.get("function")
-                corrupt_layer = kwargs.get("layer_num", -1)
-                corrupt_k = kwargs.get("k", -1)
-                corrupt_c = kwargs.get("c", -1)
-                corrupt_kH = kwargs.get("h", -1)
-                corrupt_kW = kwargs.get("w", -1)
+                corrupt_layer = kwargs.get("layer_num", list())
+                corrupt_k = kwargs.get("k", list())
+                corrupt_c = kwargs.get("c", list())
+                corrupt_kH = kwargs.get("h", list())
+                corrupt_kW = kwargs.get("w", list())
             else:
-                corrupt_layer = kwargs.get("layer_num", -1)
-                corrupt_k = kwargs.get("k", -1)
-                corrupt_c = kwargs.get("c", -1)
-                corrupt_kH = kwargs.get("h", -1)
-                corrupt_kW = kwargs.get("w", -1)
-                corrupt_value = kwargs.get("value", -1)
+                corrupt_layer = kwargs.get("layer_num", )
+                corrupt_k = kwargs.get("k", list())
+                corrupt_c = kwargs.get("c", list())
+                corrupt_kH = kwargs.get("h", list())
+                corrupt_kW = kwargs.get("w", list())
+                corrupt_value = kwargs.get("value", list())
         else:
             raise ValueError("Please specify an injection or injection function")
 
@@ -168,18 +168,18 @@ class fault_injection:
         if kwargs:
             if "function" in kwargs:
                 CUSTOM_INJECTION, INJECTION_FUNCTION = True, kwargs.get("function")
-                self.CORRUPT_LAYER = kwargs.get("layer_num", -1)
-                self.CORRUPT_BATCH = kwargs.get("batch", -1)
-                self.CORRUPT_C = kwargs.get("c", -1)
-                self.CORRUPT_H = kwargs.get("h", -1)
-                self.CORRUPT_W = kwargs.get("w", -1)
+                self.CORRUPT_LAYER = kwargs.get("layer_num", list())
+                self.CORRUPT_BATCH = kwargs.get("batch", list())
+                self.CORRUPT_C = kwargs.get("c", list())
+                self.CORRUPT_H = kwargs.get("h", list())
+                self.CORRUPT_W = kwargs.get("w", list())
             else:
-                self.CORRUPT_LAYER = kwargs.get("layer_num", -1)
-                self.CORRUPT_BATCH = kwargs.get("batch", -1)
-                self.CORRUPT_C = kwargs.get("c", -1)
-                self.CORRUPT_H = kwargs.get("h", -1)
-                self.CORRUPT_W = kwargs.get("w", -1)
-                self.CORRUPT_VALUE = kwargs.get("value", None)
+                self.CORRUPT_LAYER = kwargs.get("layer_num", list())
+                self.CORRUPT_BATCH = kwargs.get("batch", list())
+                self.CORRUPT_C = kwargs.get("c", list())
+                self.CORRUPT_H = kwargs.get("h", list())
+                self.CORRUPT_W = kwargs.get("w", list())
+                self.CORRUPT_VALUE = kwargs.get("value", list())
 
                 logging.info("Declaring Specified Fault Injector")
                 logging.info("Convolution: %s" % self.CORRUPT_LAYER)

--- a/pytorchfi/error_models.py
+++ b/pytorchfi/error_models.py
@@ -67,7 +67,7 @@ def random_neuron_inj(pfi_model, min_val=-1, max_val=1):
     err_val = random_value(min_val=min_val, max_val=max_val)
 
     return pfi_model.declare_neuron_fi(
-        batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
+        batch=[b], layer_num=[layer], c=[C], h=[H], w=[W], value=[err_val]
     )
 
 

--- a/pytorchfi/error_models.py
+++ b/pytorchfi/error_models.py
@@ -310,12 +310,12 @@ def random_neuron_single_bit_inj(pfi_model, layer_ranges):
     (layer, C, H, W) = random_neuron_location(pfi_model)
 
     return pfi_model.declare_neuron_fi(
-        batch=batch,
-        layer_num=layer,
-        c=C,
-        h=H,
-        w=W,
-        function=pfi_model.single_bit_flip_signed_across_batch,
+        batch=[batch],
+        layer_num=[layer],
+        c=[C],
+        h=[H],
+        w=[W],
+        function=pfi_model.single_bit_flip_signed_across_batch, #TODO Support multiple error models via list
     )
 
 

--- a/pytorchfi/error_models.py
+++ b/pytorchfi/error_models.py
@@ -244,31 +244,31 @@ class single_bit_flip_func(core.fault_injection):
             )
             for i in inj_list:
                 self.assert_inj_bounds(index=i)
-                prev_value = output[self.CORRUPT_BATCH[i]][self.CORRUPT_C[i]][
-                    self.CORRUPT_H[i]
-                ][self.CORRUPT_W[i]]
+                prev_value = output[self.CORRUPT_BATCH[i]][self.CORRUPT_DIM1[i]][
+                    self.CORRUPT_DIM2[i]
+                ][self.CORRUPT_DIM3[i]]
 
                 rand_bit = random.randint(0, self.bits - 1)
                 logging.info("rand_bit", rand_bit)
                 new_value = self._flip_bit_signed(prev_value, range_max, rand_bit)
 
-                output[self.CORRUPT_BATCH[i]][self.CORRUPT_C[i]][self.CORRUPT_H[i]][
-                    self.CORRUPT_W[i]
+                output[self.CORRUPT_BATCH[i]][self.CORRUPT_DIM1[i]][self.CORRUPT_DIM2[i]][
+                    self.CORRUPT_DIM3[i]
                 ] = new_value
 
         else:
             self.assert_inj_bounds()
             if self.get_curr_layer() == corrupt_conv_set:
-                prev_value = output[self.CORRUPT_BATCH][self.CORRUPT_C][self.CORRUPT_H][
-                    self.CORRUPT_W
+                prev_value = output[self.CORRUPT_BATCH][self.CORRUPT_DIM1][self.CORRUPT_DIM2][
+                    self.CORRUPT_DIM3
                 ]
 
                 rand_bit = random.randint(0, self.bits - 1)
                 logging.info("rand_bit", rand_bit)
                 new_value = self._flip_bit_signed(prev_value, range_max, rand_bit)
 
-                output[self.CORRUPT_BATCH][self.CORRUPT_C][self.CORRUPT_H][
-                    self.CORRUPT_W
+                output[self.CORRUPT_BATCH][self.CORRUPT_DIM1][self.CORRUPT_DIM2][
+                    self.CORRUPT_DIM3
                 ] = new_value
 
         self.updateConv()

--- a/pytorchfi/error_models.py
+++ b/pytorchfi/error_models.py
@@ -19,7 +19,7 @@ def random_batch_element(pfi_model):
 
 def random_neuron_location(pfi_model, conv=-1):
     if conv == -1:
-        conv = random.randint(0, pfi_model.get_total_conv() - 1)
+        conv = random.randint(0, pfi_model.get_total_layers() - 1)
 
     c = random.randint(0, pfi_model.get_fmaps_num(conv) - 1)
     h = random.randint(0, pfi_model.get_fmaps_H(conv) - 1)
@@ -32,7 +32,7 @@ def random_weight_location(pfi_model, conv=-1):
     loc = list()
 
     if conv == -1:
-        corrupt_layer = random.randint(0, pfi_model.get_total_conv() - 1)
+        corrupt_layer = random.randint(0, pfi_model.get_total_layers() - 1)
     else:
         corrupt_layer = conv
     loc.append(corrupt_layer)
@@ -45,7 +45,7 @@ def random_weight_location(pfi_model, conv=-1):
                     loc.append(random.randint(0, dim - 1))
             curr_layer += 1
 
-    assert curr_layer == pfi_model.get_total_conv()
+    assert curr_layer == pfi_model.get_total_layers()
     assert len(loc) == 5
 
     return tuple(loc)
@@ -105,7 +105,7 @@ def random_inj_per_layer(pfi_model, min_val=-1, max_val=1):
     batch, conv_num, c_rand, h_rand, w_rand, value = ([] for i in range(6))
 
     b = random_batch_element(pfi_model)
-    for i in range(pfi_model.get_total_conv()):
+    for i in range(pfi_model.get_total_layers()):
         (conv, C, H, W) = random_neuron_location(pfi_model, conv=i)
         batch.append(b)
         conv_num.append(conv)
@@ -125,7 +125,7 @@ def random_inj_per_layer_batched(
 ):
     batch, conv_num, c_rand, h_rand, w_rand, value = ([] for i in range(6))
 
-    for i in range(pfi_model.get_total_conv()):
+    for i in range(pfi_model.get_total_layers()):
         if not randLoc:
             (conv, C, H, W) = random_neuron_location(pfi_model, conv=i)
         if not randVal:
@@ -272,7 +272,7 @@ class single_bit_flip_func(core.fault_injection):
                 ] = new_value
 
         self.updateConv()
-        if self.get_curr_conv() >= self.get_total_conv():
+        if self.get_curr_conv() >= self.get_total_layers():
             self.reset_curr_conv()
 
 

--- a/pytorchfi/error_models.py
+++ b/pytorchfi/error_models.py
@@ -17,24 +17,24 @@ def random_batch_element(pfi_model):
     return random.randint(0, pfi_model.get_total_batches() - 1)
 
 
-def random_neuron_location(pfi_model, conv=-1):
-    if conv == -1:
-        conv = random.randint(0, pfi_model.get_total_layers() - 1)
+def random_neuron_location(pfi_model, layer=-1):
+    if layer == -1:
+        layer = random.randint(0, pfi_model.get_total_layers() - 1)
 
-    c = random.randint(0, pfi_model.get_fmaps_num(conv) - 1)
-    h = random.randint(0, pfi_model.get_fmaps_H(conv) - 1)
-    w = random.randint(0, pfi_model.get_fmaps_W(conv) - 1)
+    c = random.randint(0, pfi_model.get_fmaps_num(layer) - 1)
+    h = random.randint(0, pfi_model.get_fmaps_H(layer) - 1)
+    w = random.randint(0, pfi_model.get_fmaps_W(layer) - 1)
 
-    return (conv, c, h, w)
+    return (layer, c, h, w)
 
 
-def random_weight_location(pfi_model, conv=-1):
+def random_weight_location(pfi_model, layer=-1):
     loc = list()
 
-    if conv == -1:
+    if layer == -1:
         corrupt_layer = random.randint(0, pfi_model.get_total_layers() - 1)
     else:
-        corrupt_layer = conv
+        corrupt_layer = layer
     loc.append(corrupt_layer)
 
     curr_layer = 0
@@ -63,11 +63,11 @@ Neuron Perturbation Models
 # single random neuron error in single batch element
 def random_neuron_inj(pfi_model, min_val=-1, max_val=1):
     b = random_batch_element(pfi_model)
-    (conv, C, H, W) = random_neuron_location(pfi_model)
+    (layer, C, H, W) = random_neuron_location(pfi_model)
     err_val = random_value(min_val=min_val, max_val=max_val)
 
     return pfi_model.declare_neuron_fi(
-        batch=b, conv_num=conv, c=C, h=H, w=W, value=err_val
+        batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
     )
 
 
@@ -75,47 +75,47 @@ def random_neuron_inj(pfi_model, min_val=-1, max_val=1):
 def random_neuron_inj_batched(
     pfi_model, min_val=-1, max_val=1, randLoc=True, randVal=True
 ):
-    batch, conv_num, c_rand, h_rand, w_rand, value = ([] for i in range(6))
+    batch, layer_num, c_rand, h_rand, w_rand, value = ([] for i in range(6))
 
     if not randLoc:
-        (conv, C, H, W) = random_neuron_location(pfi_model)
+        (layer, C, H, W) = random_neuron_location(pfi_model)
     if not randVal:
         err_val = random_value(min_val=min_val, max_val=max_val)
 
     for i in range(pfi_model.get_total_batches()):
         if randLoc:
-            (conv, C, H, W) = random_neuron_location(pfi_model)
+            (layer, C, H, W) = random_neuron_location(pfi_model)
         if randVal:
             err_val = random_value(min_val=min_val, max_val=max_val)
 
         batch.append(i)
-        conv_num.append(conv)
+        layer_num.append(layer)
         c_rand.append(C)
         h_rand.append(H)
         w_rand.append(W)
         value.append(err_val)
 
     return pfi_model.declare_neuron_fi(
-        batch=batch, conv_num=conv_num, c=c_rand, h=h_rand, w=w_rand, value=value
+        batch=batch, layer_num=layer_num, c=c_rand, h=h_rand, w=w_rand, value=value
     )
 
 
 # one random neuron error per layer in single batch element
 def random_inj_per_layer(pfi_model, min_val=-1, max_val=1):
-    batch, conv_num, c_rand, h_rand, w_rand, value = ([] for i in range(6))
+    batch, layer_num, c_rand, h_rand, w_rand, value = ([] for i in range(6))
 
     b = random_batch_element(pfi_model)
     for i in range(pfi_model.get_total_layers()):
-        (conv, C, H, W) = random_neuron_location(pfi_model, conv=i)
+        (layer, C, H, W) = random_neuron_location(pfi_model, layer=i)
         batch.append(b)
-        conv_num.append(conv)
+        layer_num.append(layer)
         c_rand.append(C)
         h_rand.append(H)
         w_rand.append(W)
         value.append(random_value(min_val=min_val, max_val=max_val))
 
     return pfi_model.declare_neuron_fi(
-        batch=batch, conv_num=conv_num, c=c_rand, h=h_rand, w=w_rand, value=value
+        batch=batch, layer_num=layer_num, c=c_rand, h=h_rand, w=w_rand, value=value
     )
 
 
@@ -123,29 +123,29 @@ def random_inj_per_layer(pfi_model, min_val=-1, max_val=1):
 def random_inj_per_layer_batched(
     pfi_model, min_val=-1, max_val=1, randLoc=True, randVal=True
 ):
-    batch, conv_num, c_rand, h_rand, w_rand, value = ([] for i in range(6))
+    batch, layer_num, c_rand, h_rand, w_rand, value = ([] for i in range(6))
 
     for i in range(pfi_model.get_total_layers()):
         if not randLoc:
-            (conv, C, H, W) = random_neuron_location(pfi_model, conv=i)
+            (layer, C, H, W) = random_neuron_location(pfi_model, layer=i)
         if not randVal:
             err_val = random_value(min_val=min_val, max_val=max_val)
 
         for b in range(pfi_model.get_total_batches()):
             if randLoc:
-                (conv, C, H, W) = random_neuron_location(pfi_model, conv=i)
+                (layer, C, H, W) = random_neuron_location(pfi_model, layer=i)
             if randVal:
                 err_val = random_value(min_val=min_val, max_val=max_val)
 
             batch.append(b)
-            conv_num.append(conv)
+            layer_num.append(layer)
             c_rand.append(C)
             h_rand.append(H)
             w_rand.append(W)
             value.append(err_val)
 
     return pfi_model.declare_neuron_fi(
-        batch=batch, conv_num=conv_num, c=c_rand, h=h_rand, w=w_rand, value=value
+        batch=batch, layer_num=layer_num, c=c_rand, h=h_rand, w=w_rand, value=value
     )
 
 
@@ -230,15 +230,15 @@ class single_bit_flip_func(core.fault_injection):
         return torch.tensor(new_value, dtype=save_type)
 
     def single_bit_flip_signed_across_batch(self, module, input, output):
-        corrupt_conv_set = self.get_corrupt_conv()
-        range_max = self.get_conv_max(self.get_curr_conv())
-        logging.info("curr_conv", self.get_curr_conv())
+        corrupt_conv_set = self.get_corrupt_layer()
+        range_max = self.get_conv_max(self.get_curr_layer())
+        logging.info("curr_conv", self.get_curr_layer())
         logging.info("range_max", range_max)
 
         if type(corrupt_conv_set) == list:
             inj_list = list(
                 filter(
-                    lambda x: corrupt_conv_set[x] == self.get_curr_conv(),
+                    lambda x: corrupt_conv_set[x] == self.get_curr_layer(),
                     range(len(corrupt_conv_set)),
                 )
             )
@@ -258,7 +258,7 @@ class single_bit_flip_func(core.fault_injection):
 
         else:
             self.assert_inj_bounds()
-            if self.get_curr_conv() == corrupt_conv_set:
+            if self.get_curr_layer() == corrupt_conv_set:
                 prev_value = output[self.CORRUPT_BATCH][self.CORRUPT_C][self.CORRUPT_H][
                     self.CORRUPT_W
                 ]
@@ -272,30 +272,30 @@ class single_bit_flip_func(core.fault_injection):
                 ] = new_value
 
         self.updateConv()
-        if self.get_curr_conv() >= self.get_total_layers():
-            self.reset_curr_conv()
+        if self.get_curr_layer() >= self.get_total_layers():
+            self.reset_curr_layer()
 
 
 def random_neuron_single_bit_inj_batched(pfi_model, layer_ranges, randLoc=True):
     pfi_model.set_conv_max(layer_ranges)
-    batch, conv_num, c_rand, h_rand, w_rand = ([] for i in range(5))
+    batch, layer_num, c_rand, h_rand, w_rand = ([] for i in range(5))
 
     if not randLoc:
-        (conv, C, H, W) = random_neuron_location(pfi_model)
+        (layer, C, H, W) = random_neuron_location(pfi_model)
 
     for i in range(pfi_model.get_total_batches()):
         if randLoc:
-            (conv, C, H, W) = random_neuron_location(pfi_model)
+            (layer, C, H, W) = random_neuron_location(pfi_model)
 
         batch.append(i)
-        conv_num.append(conv)
+        layer_num.append(layer)
         c_rand.append(C)
         h_rand.append(H)
         w_rand.append(W)
 
     return pfi_model.declare_neuron_fi(
         batch=batch,
-        conv_num=conv_num,
+        layer_num=layer_num,
         c=c_rand,
         h=h_rand,
         w=w_rand,
@@ -307,11 +307,11 @@ def random_neuron_single_bit_inj(pfi_model, layer_ranges):
     pfi_model.set_conv_max(layer_ranges)
 
     batch = random_batch_element(pfi_model)
-    (conv, C, H, W) = random_neuron_location(pfi_model)
+    (layer, C, H, W) = random_neuron_location(pfi_model)
 
     return pfi_model.declare_neuron_fi(
         batch=batch,
-        conv_num=conv,
+        layer_num=layer,
         c=C,
         h=H,
         w=W,
@@ -325,18 +325,18 @@ Weight Perturbation Models
 
 
 def random_weight_inj(pfi_model, corrupt_conv=-1, min_val=-1, max_val=1):
-    (conv, k, c_in, kH, kW) = random_weight_location(pfi_model, corrupt_conv)
+    (layer, k, c_in, kH, kW) = random_weight_location(pfi_model, corrupt_conv)
     faulty_val = random_value(min_val=min_val, max_val=max_val)
 
     return pfi_model.declare_weight_fi(
-        conv_num=conv, k=k, c=c_in, h=kH, w=kW, value=faulty_val
+        layer_num=layer, k=k, c=c_in, h=kH, w=kW, value=faulty_val
     )
 
 
 def zeroFunc_rand_weight(pfi_model):
-    (conv, k, c_in, kH, kW) = random_weight_location(pfi_model)
+    (layer, k, c_in, kH, kW) = random_weight_location(pfi_model)
     return pfi_model.declare_weight_fi(
-        function=_zero_rand_weight, conv_num=conv, k=k, c=c_in, h=kH, w=kW
+        function=_zero_rand_weight, layer_num=layer, k=k, c=c_in, h=kH, w=kW
     )
 
 

--- a/pytorchfi/error_models.py
+++ b/pytorchfi/error_models.py
@@ -271,7 +271,7 @@ class single_bit_flip_func(core.fault_injection):
                     self.CORRUPT_DIM3
                 ] = new_value
 
-        self.updateConv()
+        self.updateLayer()
         if self.get_curr_layer() >= self.get_total_layers():
             self.reset_curr_layer()
 

--- a/test/unit_tests/test_example_client.py
+++ b/test/unit_tests/test_example_client.py
@@ -43,7 +43,7 @@ class TestCoreExampleClient:
     def test_single_specified_neuron(self):
         (b, layer, C, H, W, err_val) = (0, 3, 4, 2, 4, 10000)
         inj = self.p.declare_neuron_fi(
-            batch=b, conv_num=layer, c=C, h=H, w=W, value=err_val
+            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
         )
         inj_output = inj(self.IMAGE)
         inj_softmax = self.softmax(inj_output)
@@ -61,7 +61,7 @@ class TestCoreExampleClient:
             [20000, 10000],
         )
         inj = self.p.declare_neuron_fi(
-            batch=b, conv_num=layer, c=C, h=H, w=W, value=err_val
+            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
         )
         inj_output = inj(self.IMAGE)
         inj_softmax = self.softmax(inj_output)

--- a/test/unit_tests/test_example_client.py
+++ b/test/unit_tests/test_example_client.py
@@ -41,7 +41,7 @@ class TestCoreExampleClient:
         assert self.golden_label == 556
 
     def test_single_specified_neuron(self):
-        (b, layer, C, H, W, err_val) = (0, 3, 4, 2, 4, 10000)
+        (b, layer, C, H, W, err_val) = ([0], [3], [4], [2], [4], [10000])
         inj = self.p.declare_neuron_fi(
             batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
         )

--- a/test/unit_tests/test_get_funcs.py
+++ b/test/unit_tests/test_get_funcs.py
@@ -49,8 +49,14 @@ class TestCoreGetFuncs:
     def test_get_total_batches(self):
         assert self.p.get_total_batches() == 4
 
-    def test_get_layer_types(self):
-        assert self.p.get_layer_types() == [torch.nn.Conv2d]
+    def test_get_inj_layer_types(self):
+        assert self.p.get_inj_layer_types() == [torch.nn.Conv2d]
+
+    def test_get_layer_type(self):
+        assert self.p.get_layer_type(3) == torch.nn.Conv2d
+
+    def test_get_layer_dim(self):
+        assert self.p.get_layer_dim(3) == 4
 
     def test_get_total_layers(self):
         assert self.p.get_total_layers() == 5

--- a/test/unit_tests/test_get_funcs.py
+++ b/test/unit_tests/test_get_funcs.py
@@ -52,8 +52,8 @@ class TestCoreGetFuncs:
     def test_get_layer_types(self):
         assert self.p.get_layer_types() == [torch.nn.Conv2d]
 
-    def test_get_total_conv(self):
-        assert self.p.get_total_conv() == 5
+    def test_get_total_layers(self):
+        assert self.p.get_total_layers() == 5
 
     def test_get_fmap_num(self):
         assert self.p.get_fmaps_num(0) == 64

--- a/test/unit_tests/test_layers.py
+++ b/test/unit_tests/test_layers.py
@@ -52,7 +52,6 @@ class TestLayers:
         inj_softmax = self.softmax(inj_output)
         inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
 
-        print(p.get_total_layers())
         assert inj_label == 578
 
     @pytest.mark.skip(reason="Under development")

--- a/test/unit_tests/test_layers.py
+++ b/test/unit_tests/test_layers.py
@@ -1,0 +1,161 @@
+import torch
+import torchvision.models as models
+from pytorchfi.core import fault_injection
+import pytest
+
+class TestLayers:
+    """
+    Testing PyTorchFI.Core example client.
+    """
+
+    def setup_class(self):
+        torch.manual_seed(5)
+
+        self.H = 224
+        self.W = 224
+        self.BATCH_SIZE = 4
+
+        self.IMAGE = torch.rand((self.BATCH_SIZE, 3, self.H, self.W))
+
+        self.USE_GPU = False
+
+        self.softmax = torch.nn.Softmax(dim=1)
+
+        self.model = models.alexnet(pretrained=True)
+        self.model.eval()
+
+        # Error free inference to gather golden value
+        self.output = self.model(self.IMAGE)
+        self.golden_softmax = self.softmax(self.output)
+        self.golden_label = list(torch.argmax(self.golden_softmax, dim=1))[0].item()
+
+    def test_golden_inference(self):
+        assert self.golden_label == 556
+
+    def test_single_conv_neuron(self):
+
+        p = fault_injection(
+            self.model,
+            self.H,
+            self.W,
+            self.BATCH_SIZE,
+            layer_types=[torch.nn.Conv2d],
+            use_cuda=self.USE_GPU,
+        )
+
+
+        (b, layer, C, H, W, err_val) = (0, 3, 4, 2, 4, 10000)
+        inj = p.declare_neuron_fi(
+            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
+        )
+        inj_output = inj(self.IMAGE)
+        inj_softmax = self.softmax(inj_output)
+        inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
+
+        print(p.get_total_layers())
+        assert inj_label == 578
+
+    @pytest.mark.skip(reason="Under development")
+    def test_single_linear_neuron(self):
+        p = fault_injection(
+            self.model,
+            self.H,
+            self.W,
+            self.BATCH_SIZE,
+            layer_types=[torch.nn.Linear],
+            use_cuda=self.USE_GPU,
+        )
+
+        (b, layer, C, H, W, err_val) = (0, 3, 4, 2, 4, 10000)
+        inj = p.declare_neuron_fi(
+            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
+        )
+        inj_output = inj(self.IMAGE)
+        inj_softmax = self.softmax(inj_output)
+        inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
+
+        assert inj_label == 578
+
+    @pytest.mark.skip(reason="Under development")
+    def test_combo_layers(self):
+        p = fault_injection(
+            self.model,
+            self.H,
+            self.W,
+            self.BATCH_SIZE,
+            layer_types=[torch.nn.Conv2d, torch.nn.Linear],
+            use_cuda=self.USE_GPU,
+        )
+
+        (b, layer, C, H, W, err_val) = (
+            [0, 0],
+            [1, 3],
+            [5, 4],
+            [5, 2],
+            [3, 4],
+            [20000, 10000],
+        )
+        inj = p.declare_neuron_fi(
+            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
+        )
+        inj_output = inj(self.IMAGE)
+        inj_softmax = self.softmax(inj_output)
+        inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
+
+        assert inj_label == 843
+
+#    def test_multiple_conv_neuron(self):
+#
+#        p = fault_injection(
+#            self.model,
+#            self.H,
+#            self.W,
+#            self.BATCH_SIZE,
+#            layer_types=[torch.nn.Conv2d],
+#            use_cuda=self.USE_GPU,
+#        )
+#
+#        (b, layer, C, H, W, err_val) = (
+#            [0, 0],
+#            [1, 3],
+#            [5, 4],
+#            [5, 2],
+#            [3, 4],
+#            [20000, 10000],
+#        )
+#        inj = p.declare_neuron_fi(
+#            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
+#        )
+#        inj_output = inj(self.IMAGE)
+#        inj_softmax = self.softmax(inj_output)
+#        inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
+#
+#        assert inj_label == 843
+#
+#    def test_multiple_linear_neuron(self):
+#        p = fault_injection(
+#            self.model,
+#            self.H,
+#            self.W,
+#            self.BATCH_SIZE,
+#            layer_types=[torch.nn.Linear],
+#            use_cuda=self.USE_GPU,
+#        )
+#
+#        (b, layer, C, H, W, err_val) = (
+#            [0, 0],
+#            [1, 3],
+#            [5, 4],
+#            [5, 2],
+#            [3, 4],
+#            [20000, 10000],
+#        )
+#        inj = p.declare_neuron_fi(
+#            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
+#        )
+#        inj_output = inj(self.IMAGE)
+#        inj_softmax = self.softmax(inj_output)
+#        inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
+#
+#        assert inj_label == 843
+#

--- a/test/unit_tests/test_layers.py
+++ b/test/unit_tests/test_layers.py
@@ -88,7 +88,6 @@ class TestLayers:
 
         assert inj_label == 888
 
-    @pytest.mark.skip(reason="Under development")
     def test_combo_layers(self):
         p = fault_injection(
             self.model,
@@ -96,15 +95,16 @@ class TestLayers:
             self.W,
             self.BATCH_SIZE,
             layer_types=[torch.nn.Conv2d, torch.nn.Linear],
+            # layer_types=[torch.nn.Conv2d],
             use_cuda=self.USE_GPU,
         )
 
         (b, layer, C, H, W, err_val) = (
-            [0, 0],
-            [1, 3],
-            [5, 4],
-            [5, 2],
-            [3, 4],
+            [0, 1],
+            [1, 7],
+            [5, 888],
+            [5, None],
+            [3, None],
             [20000, 10000],
         )
         inj = p.declare_neuron_fi(
@@ -112,62 +112,9 @@ class TestLayers:
         )
         inj_output = inj(self.IMAGE)
         inj_softmax = self.softmax(inj_output)
-        inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
+        inj_label_1 = list(torch.argmax(inj_softmax, dim=1))[0].item()
+        inj_label_2 = list(torch.argmax(inj_softmax, dim=1))[1].item()
 
-        assert inj_label == 843
-
-#    def test_multiple_conv_neuron(self):
-#
-#        p = fault_injection(
-#            self.model,
-#            self.H,
-#            self.W,
-#            self.BATCH_SIZE,
-#            layer_types=[torch.nn.Conv2d],
-#            use_cuda=self.USE_GPU,
-#        )
-#
-#        (b, layer, C, H, W, err_val) = (
-#            [0, 0],
-#            [1, 3],
-#            [5, 4],
-#            [5, 2],
-#            [3, 4],
-#            [20000, 10000],
-#        )
-#        inj = p.declare_neuron_fi(
-#            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
-#        )
-#        inj_output = inj(self.IMAGE)
-#        inj_softmax = self.softmax(inj_output)
-#        inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
-#
-#        assert inj_label == 843
-#
-#    def test_multiple_linear_neuron(self):
-#        p = fault_injection(
-#            self.model,
-#            self.H,
-#            self.W,
-#            self.BATCH_SIZE,
-#            layer_types=[torch.nn.Linear],
-#            use_cuda=self.USE_GPU,
-#        )
-#
-#        (b, layer, C, H, W, err_val) = (
-#            [0, 0],
-#            [1, 3],
-#            [5, 4],
-#            [5, 2],
-#            [3, 4],
-#            [20000, 10000],
-#        )
-#        inj = p.declare_neuron_fi(
-#            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
-#        )
-#        inj_output = inj(self.IMAGE)
-#        inj_softmax = self.softmax(inj_output)
-#        inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
-#
-#        assert inj_label == 843
-#
+        assert p.get_total_layers() == 8
+        assert inj_label_1 == 695
+        assert inj_label_2 == 888

--- a/test/unit_tests/test_layers.py
+++ b/test/unit_tests/test_layers.py
@@ -54,8 +54,7 @@ class TestLayers:
 
         assert inj_label == 578
 
-    @pytest.mark.skip(reason="Under development")
-    def test_single_linear_neuron(self):
+    def test_single_linear_layer(self):
         p = fault_injection(
             self.model,
             self.H,
@@ -65,15 +64,29 @@ class TestLayers:
             use_cuda=self.USE_GPU,
         )
 
-        (b, layer, C, H, W, err_val) = (0, 3, 4, 2, 4, 10000)
+        assert p.get_total_layers() == 3
+        assert p.get_layer_dim(2) == 2
+        assert p.get_layer_type(2) == torch.nn.Linear
+
+    def test_single_linear_neuron_inj(self):
+        p = fault_injection(
+            self.model,
+            self.H,
+            self.W,
+            self.BATCH_SIZE,
+            layer_types=[torch.nn.Linear],
+            use_cuda=self.USE_GPU,
+        )
+
+        (b, layer, C, H, W, err_val) = (0, 2, 888, None, None, 10000)
         inj = p.declare_neuron_fi(
-            batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
+            batch=[b], layer_num=[layer], c=[C], h=[H], w=[W], value=[err_val]
         )
         inj_output = inj(self.IMAGE)
         inj_softmax = self.softmax(inj_output)
         inj_label = list(torch.argmax(inj_softmax, dim=1))[0].item()
 
-        assert inj_label == 578
+        assert inj_label == 888
 
     @pytest.mark.skip(reason="Under development")
     def test_combo_layers(self):

--- a/test/unit_tests/test_layers.py
+++ b/test/unit_tests/test_layers.py
@@ -44,7 +44,7 @@ class TestLayers:
         )
 
 
-        (b, layer, C, H, W, err_val) = (0, 3, 4, 2, 4, 10000)
+        (b, layer, C, H, W, err_val) = ([0], [3], [4], [2], [4], [10000])
         inj = p.declare_neuron_fi(
             batch=b, layer_num=layer, c=C, h=H, w=W, value=err_val
         )

--- a/test/unit_tests/test_neuron_fi.py
+++ b/test/unit_tests/test_neuron_fi.py
@@ -45,7 +45,7 @@ class TestNeuronFIgpu:
     )
     def test_neuronFI_singleElement(self):
         batch_i = 0
-        conv_i = 4
+        layer_i = 4
         c_i = 0
         h_i = 1
         w_i = 1
@@ -53,7 +53,7 @@ class TestNeuronFIgpu:
         inj_value_i = 10000.0
 
         self.inj_model = self.p.declare_neuron_fi(
-            batch=batch_i, conv_num=conv_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
+            batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
         )
 
         self.inj_model.eval()
@@ -64,7 +64,7 @@ class TestNeuronFIgpu:
 
         self.inj_model = self.p.declare_neuron_fi(
             batch=batch_i,
-            conv_num=conv_i,
+            layer_num=layer_i,
             c=c_i,
             h=h_i,
             w=w_i,
@@ -78,7 +78,7 @@ class TestNeuronFIgpu:
         assert torch.all(uncorrupted_output.eq(self.output))
 
         self.inj_model = self.p.declare_neuron_fi(
-            batch=batch_i, conv_num=conv_i, c=c_i, h=h_i, w=w_i, value=inj_value_i * 2
+            batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i * 2
         )
 
         self.inj_model.eval()
@@ -123,7 +123,7 @@ class TestNeuronFIcpu:
 
     def test_neuronFI_singleElement(self):
         batch_i = 0
-        conv_i = 4
+        layer_i = 4
         c_i = 0
         h_i = 1
         w_i = 1
@@ -131,7 +131,7 @@ class TestNeuronFIcpu:
         inj_value_i = 10000.0
 
         self.inj_model = self.p.declare_neuron_fi(
-            batch=batch_i, conv_num=conv_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
+            batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
         )
 
         self.inj_model.eval()
@@ -142,7 +142,7 @@ class TestNeuronFIcpu:
 
         self.inj_model = self.p.declare_neuron_fi(
             batch=batch_i,
-            conv_num=conv_i,
+            layer_num=layer_i,
             c=c_i,
             h=h_i,
             w=w_i,
@@ -156,7 +156,7 @@ class TestNeuronFIcpu:
         assert torch.all(uncorrupted_output.eq(self.output))
 
         self.inj_model = self.p.declare_neuron_fi(
-            batch=batch_i, conv_num=conv_i, c=c_i, h=h_i, w=w_i, value=inj_value_i * 2
+            batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i * 2
         )
 
         self.inj_model.eval()
@@ -208,7 +208,7 @@ class TestNeuronFIgpuBatch:
     def test_neuronFI_batch_1(self):
 
         batch_i = 2
-        conv_i = 4
+        layer_i = 4
         c_i = 0
         h_i = 1
         w_i = 1
@@ -216,7 +216,7 @@ class TestNeuronFIgpuBatch:
         inj_value_i = 10000.0
 
         self.inj_model = self.p.declare_neuron_fi(
-            batch=batch_i, conv_num=conv_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
+            batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
         )
 
         self.inj_model.eval()
@@ -234,7 +234,7 @@ class TestNeuronFIgpuBatch:
     def test_neuronFI_batch_2(self):
 
         batch_i = [0, 2, 3]
-        conv_i = [1, 2, 4]
+        layer_i = [1, 2, 4]
         c_i = [3, 1, 1]
         h_i = [1, 0, 1]
         w_i = [0, 1, 0]
@@ -242,7 +242,7 @@ class TestNeuronFIgpuBatch:
         inj_value_i = [10000.0, 10000.0, 10000.0]
 
         self.inj_model = self.p.declare_neuron_fi(
-            batch=batch_i, conv_num=conv_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
+            batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
         )
 
         self.inj_model.eval()
@@ -289,7 +289,7 @@ class TestNeuronFIcpuBatch:
 
     def test_neuronFI_batch_1(self):
         batch_i = 2
-        conv_i = 4
+        layer_i = 4
         c_i = 0
         h_i = 1
         w_i = 1
@@ -297,7 +297,7 @@ class TestNeuronFIcpuBatch:
         inj_value_i = 10000.0
 
         self.inj_model = self.p.declare_neuron_fi(
-            batch=batch_i, conv_num=conv_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
+            batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
         )
 
         self.inj_model.eval()
@@ -311,7 +311,7 @@ class TestNeuronFIcpuBatch:
 
     def test_neuronFI_batch_2(self):
         batch_i = [0, 2, 3]
-        conv_i = [1, 2, 4]
+        layer_i = [1, 2, 4]
         c_i = [3, 1, 1]
         h_i = [1, 0, 1]
         w_i = [0, 1, 0]
@@ -319,7 +319,7 @@ class TestNeuronFIcpuBatch:
         inj_value_i = [10000.0, 10000.0, 10000.0]
 
         self.inj_model = self.p.declare_neuron_fi(
-            batch=batch_i, conv_num=conv_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
+            batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
         )
 
         self.inj_model.eval()

--- a/test/unit_tests/test_neuron_fi.py
+++ b/test/unit_tests/test_neuron_fi.py
@@ -44,13 +44,13 @@ class TestNeuronFIgpu:
         not torch.cuda.is_available(), reason="GPU not supported on this machine"
     )
     def test_neuronFI_singleElement(self):
-        batch_i = 0
-        layer_i = 4
-        c_i = 0
-        h_i = 1
-        w_i = 1
+        batch_i = [0]
+        layer_i = [4]
+        c_i = [0]
+        h_i = [1]
+        w_i = [1]
 
-        inj_value_i = 10000.0
+        inj_value_i = [10000.0]
 
         self.inj_model = self.p.declare_neuron_fi(
             batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
@@ -68,7 +68,7 @@ class TestNeuronFIgpu:
             c=c_i,
             h=h_i,
             w=w_i,
-            value=0,
+            value=[0],
         )
 
         self.inj_model.eval()
@@ -122,13 +122,13 @@ class TestNeuronFIcpu:
         )
 
     def test_neuronFI_singleElement(self):
-        batch_i = 0
-        layer_i = 4
-        c_i = 0
-        h_i = 1
-        w_i = 1
+        batch_i = [0]
+        layer_i = [4]
+        c_i = [0]
+        h_i = [1]
+        w_i = [1]
 
-        inj_value_i = 10000.0
+        inj_value_i = [10000.0]
 
         self.inj_model = self.p.declare_neuron_fi(
             batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
@@ -146,7 +146,7 @@ class TestNeuronFIcpu:
             c=c_i,
             h=h_i,
             w=w_i,
-            value=0,
+            value=[0],
         )
 
         self.inj_model.eval()
@@ -207,13 +207,13 @@ class TestNeuronFIgpuBatch:
     )
     def test_neuronFI_batch_1(self):
 
-        batch_i = 2
-        layer_i = 4
-        c_i = 0
-        h_i = 1
-        w_i = 1
+        batch_i = [2]
+        layer_i = [4]
+        c_i = [0]
+        h_i = [1]
+        w_i = [1]
 
-        inj_value_i = 10000.0
+        inj_value_i = [10000.0]
 
         self.inj_model = self.p.declare_neuron_fi(
             batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i
@@ -288,13 +288,13 @@ class TestNeuronFIcpuBatch:
         )
 
     def test_neuronFI_batch_1(self):
-        batch_i = 2
-        layer_i = 4
-        c_i = 0
-        h_i = 1
-        w_i = 1
+        batch_i = [2]
+        layer_i = [4]
+        c_i = [0]
+        h_i = [1]
+        w_i = [1]
 
-        inj_value_i = 10000.0
+        inj_value_i = [10000.0]
 
         self.inj_model = self.p.declare_neuron_fi(
             batch=batch_i, layer_num=layer_i, c=c_i, h=h_i, w=w_i, value=inj_value_i

--- a/test/unit_tests/test_weight_fi.py
+++ b/test/unit_tests/test_weight_fi.py
@@ -37,7 +37,7 @@ class TestWeightFIcpu:
         )
 
     def test_neuronFI_singleElement(self):
-        conv_i = 1
+        layer_i = 1
         k = 15
         c_i = 20
         h_i = 2
@@ -46,7 +46,7 @@ class TestWeightFIcpu:
         inj_value_i = 10000.0
 
         self.inj_model = self.p.declare_weight_fi(
-            conv_num=conv_i, k=k, c=c_i, h=h_i, w=w_i, value=inj_value_i
+            layer_num=layer_i, k=k, c=c_i, h=h_i, w=w_i, value=inj_value_i
         )
 
         self.inj_model.eval()
@@ -56,7 +56,7 @@ class TestWeightFIcpu:
         assert not torch.all(corrupted_output_1.eq(self.output))
 
         self.inj_model = self.p.declare_weight_fi(
-            conv_num=conv_i,
+            layer_num=layer_i,
             k=k,
             c=c_i,
             h=h_i,
@@ -71,7 +71,7 @@ class TestWeightFIcpu:
         assert torch.all(uncorrupted_output.eq(self.output))
 
         self.inj_model = self.p.declare_weight_fi(
-            conv_num=conv_i,
+            layer_num=layer_i,
             k=k,
             c=c_i,
             h=h_i,
@@ -87,7 +87,7 @@ class TestWeightFIcpu:
         assert torch.all(corrupted_output_2.eq(corrupted_output_2))
 
     def test_neuronFI_singleElement_noErr(self):
-        conv_i = 4
+        layer_i = 4
         k = 153
         c_i = 254
         h_i = 0
@@ -96,7 +96,7 @@ class TestWeightFIcpu:
         inj_value_i = 10000.0
 
         self.inj_model = self.p.declare_weight_fi(
-            conv_num=conv_i, k=k, c=c_i, h=h_i, w=w_i, value=inj_value_i
+            layer_num=layer_i, k=k, c=c_i, h=h_i, w=w_i, value=inj_value_i
         )
 
         self.inj_model.eval()


### PR DESCRIPTION
- Logic changes from conv --> layer throughout
- Save metadata about layer types and dims internally
- Injections always passed in as a list (previously allowed single sites). This simplifies logic and reduces code redundancy.
- Improved bound checking with debug info
- Process 2D vs 4D layer injections appropriately to support any layer type
- Updated test cases

Closes #43, Closes #55 