### PR TITLE
Generalization of inputs beyond images

### DIFF
--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -11,16 +11,18 @@ import torch.nn as nn
 
 
 class fault_injection:
-    def __init__(self, model, h, w, batch_size, layer_types=[nn.Conv2d], **kwargs):
+    def __init__(self, model, batch_size, input_shape=[3, 224, 224], layer_types=[nn.Conv2d], **kwargs):
         logging.basicConfig(format="%(asctime)-15s %(clientip)s %(user)-8s %(message)s")
-        self.ORIG_MODEL = None
-        self.CORRUPTED_MODEL = None
 
+        self.ORIG_MODEL = model
         self.OUTPUT_SIZE = list()
         self.LAYERS_TYPE = list()
         self.LAYERS_DIM = list()
-        self._BATCH_SIZE = -1
+        self._INPUT_SHAPE = input_shape
+        self._BATCH_SIZE = batch_size
+        self._INJ_LAYER_TYPES = layer_types
 
+        self.CORRUPTED_MODEL = None
         self.CURR_LAYER = 0
         self.HANDLES = list()
         self.CORRUPT_BATCH = list()
@@ -33,26 +35,21 @@ class fault_injection:
         self.CUSTOM_INJECTION = False
         self.INJECTION_FUNCTION = None
 
-        self.imageC = kwargs.get("c", 3)
-        self.imageH = h
-        self.imageW = w
-
         self.use_cuda = kwargs.get("use_cuda", next(model.parameters()).is_cuda)
-        model_dtype = next(model.parameters()).dtype
 
-        self.ORIG_MODEL = model
-        self._BATCH_SIZE = batch_size
-        self._INJ_LAYER_TYPES = layer_types
+        assert isinstance(input_shape, list), "Error: Input shape must be provided as a list."
+        assert isinstance(batch_size, int) and batch_size >= 1, "Error: Batch size must be an integer greater than 1."
+        assert len(layer_types) >= 0 , "Error: At least one layer type must be selected."
 
         handles, shapes = self._traverseModelAndSetHooks(
             self.ORIG_MODEL, self._INJ_LAYER_TYPES
         )
 
-        b = 1  # profiling only needs one batch element
-
+        dummy_shape = (1, *self._INPUT_SHAPE)  # profiling only needs one batch element
+        model_dtype = next(model.parameters()).dtype
         device = "cuda" if self.use_cuda else None
         _dummyTensor = torch.randn(
-            b, self.imageC, self.imageH, self.imageW, dtype=model_dtype, device=device
+            dummy_shape, dtype=model_dtype, device=device
         )
 
         self.ORIG_MODEL(_dummyTensor)
@@ -60,7 +57,10 @@ class fault_injection:
         for i in range(len(handles)):
             handles[i].remove()
 
-        logging.info("Model output size")
+        logging.info("Input shape:")
+        logging.info(dummy_shape[1:])
+
+        logging.info("Model layer sizes:")
         logging.info(
             "\n".join(
                 [

--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -15,11 +15,14 @@ class fault_injection:
         logging.basicConfig(format="%(asctime)-15s %(clientip)s %(user)-8s %(message)s")
         self.ORIG_MODEL = None
         self.CORRUPTED_MODEL = None
+
+        self.OUTPUT_SIZE = list()
+        self.LAYERS_TYPE = list()
+        self.LAYERS_DIM = list()
         self._BATCH_SIZE = -1
 
-        self.CUSTOM_INJECTION = False
-        self.INJECTION_FUNCTION = None
-
+        self.CURR_LAYER = 0
+        self.HANDLES = list()
         self.CORRUPT_BATCH = list()
         self.CORRUPT_LAYER = list()
         self.CORRUPT_DIM1 = list()  # C
@@ -27,11 +30,8 @@ class fault_injection:
         self.CORRUPT_DIM3 = list()  # W
         self.CORRUPT_VALUE = list()
 
-        self.CURR_LAYER = 0
-        self.OUTPUT_SIZE = []
-        self.LAYERS_TYPE = []
-        self.LAYERS_DIM = []
-        self.HANDLES = []
+        self.CUSTOM_INJECTION = False
+        self.INJECTION_FUNCTION = None
 
         self.imageC = kwargs.get("c", 3)
         self.imageH = h

--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -381,3 +381,49 @@ class fault_injection:
 
     def get_fmap_HW(self, layer):
         return (self.get_fmaps_H(layer), self.get_fmaps_W(layer))
+
+    def print_pytorchfi_layer_summary(self):
+        summary_str = "==================== PYTORCHFI INIT SUMMARY ====================="+ "\n\n"
+
+        summary_str += "Layer types allowing injections:\n"
+        summary_str += "----------------------------------------------------------------" + "\n"
+        for l_type in self._INJ_LAYER_TYPES:
+            summary_str += "{:>5}".format("- ")
+            substring = str(l_type).split(".")[-1].split("'")[0]
+            summary_str += substring
+            # summary_str += "{:>15}".format(
+            #     str(substring),
+            # )
+            summary_str += "\n"
+        summary_str += "\n"
+
+        summary_str += "Model Info:\n"
+        summary_str += "----------------------------------------------------------------" + "\n"
+
+        summary_str += "   - Shape of input into the model: ("
+        for dim in self._INPUT_SHAPE:
+            summary_str += str(dim) + " "
+        summary_str += ")\n"
+
+        summary_str += "   - Batch Size: " + str(self._BATCH_SIZE) + "\n"
+        summary_str += "   - CUDA Enabled: " + str(self.use_cuda) + "\n\n"
+
+        summary_str += "Layer Info:\n"
+        summary_str += "----------------------------------------------------------------" + "\n"
+        line_new = "{:>5}  {:>15}  {:>15} {:>20}".format(
+            "Layer #", "Layer type", "Dimensions", "Output Shape")
+        summary_str += line_new + "\n"
+        summary_str += "----------------------------------------------------------------" + "\n"
+        for layer in range(len(self.OUTPUT_SIZE)):
+            line_new = "{:>5}  {:>15}  {:>15} {:>20}".format(
+                layer,
+                str(self.LAYERS_TYPE[layer]).split(".")[-1].split("'")[0],
+                str(self.LAYERS_DIM[layer]),
+                str(self.OUTPUT_SIZE[layer]),
+            )
+            summary_str += line_new + "\n"
+
+        summary_str += "================================================================" + "\n"
+
+        return summary_str
+

--- a/pytorchfi/error_models.py
+++ b/pytorchfi/error_models.py
@@ -150,8 +150,8 @@ def random_inj_per_layer_batched(
 
 
 class single_bit_flip_func(core.fault_injection):
-    def __init__(self, model, h, w, batch_size, **kwargs):
-        super().__init__(model, h, w, batch_size, **kwargs)
+    def __init__(self, model, batch_size, input_shape=[3,224,224], **kwargs):
+        super().__init__(model, batch_size, input_shape=input_shape, **kwargs)
         logging.basicConfig(format="%(asctime)-15s %(clientip)s %(user)-8s %(message)s")
 
         self.bits = kwargs.get("bits", 8)

--- a/test/unit_tests/test_example_client.py
+++ b/test/unit_tests/test_example_client.py
@@ -11,11 +11,12 @@ class TestCoreExampleClient:
     def setup_class(self):
         torch.manual_seed(5)
 
+        self.C = 3
         self.H = 224
         self.W = 224
         self.BATCH_SIZE = 4
 
-        self.IMAGE = torch.rand((self.BATCH_SIZE, 3, self.H, self.W))
+        self.IMAGE = torch.rand((self.BATCH_SIZE, self.C, self.H, self.W))
 
         self.USE_GPU = False
 
@@ -31,9 +32,8 @@ class TestCoreExampleClient:
 
         self.p = fault_injection(
             self.model,
-            self.H,
-            self.W,
             self.BATCH_SIZE,
+            input_shape=[self.C, self.H, self.W],
             use_cuda=self.USE_GPU,
         )
 

--- a/test/unit_tests/test_get_funcs.py
+++ b/test/unit_tests/test_get_funcs.py
@@ -12,6 +12,7 @@ class TestCoreGetFuncs:
     def setup_class(self):
         self.BATCH_SIZE = 4
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.LAYER_TYPES = [torch.nn.Conv2d]
         self.USE_GPU = False
@@ -29,9 +30,8 @@ class TestCoreGetFuncs:
 
         self.p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             layer_types=self.LAYER_TYPES,
             use_cuda=self.USE_GPU,
         )

--- a/test/unit_tests/test_get_funcs.py
+++ b/test/unit_tests/test_get_funcs.py
@@ -88,3 +88,14 @@ class TestCoreGetFuncs:
         assert self.p.get_fmap_HW(2) == (2, 2)
         assert self.p.get_fmap_HW(3) == (2, 2)
         assert self.p.get_fmap_HW(4) == (2, 2)
+
+    def test_print_func(self):
+        outputString = self.p.print_pytorchfi_layer_summary()
+
+        assert "PYTORCHFI INIT SUMMARY" in outputString
+        assert "Shape of input into the model: (3 32 32 )" in outputString
+        assert "Batch Size: 4" in outputString
+        assert "Conv2d" in outputString
+        assert "CUDA Enabled: False" in outputString
+        assert "================================================================" in outputString
+

--- a/test/unit_tests/test_init.py
+++ b/test/unit_tests/test_init.py
@@ -13,6 +13,7 @@ class TestNeuronCPUSingle:
     def setup_class(self):
         self.BATCH_SIZE = 1
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = False
 
@@ -32,18 +33,16 @@ class TestNeuronCPUSingle:
         """
         pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
     def test_orig_model_cpu(self):
         p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -59,6 +58,7 @@ class TestNeuronGPUSingle:
     def setup_class(self):
         self.BATCH_SIZE = 1
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = True
 
@@ -83,9 +83,8 @@ class TestNeuronGPUSingle:
         """
         pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -95,9 +94,8 @@ class TestNeuronGPUSingle:
     def test_orig_model_gpu(self):
         p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -113,6 +111,7 @@ class TestDtypes:
     def setup_class(self):
         self.BATCH_SIZE = 1
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
 
         self.model, self.dataset = helper_setUp_CIFAR10_same(
@@ -139,9 +138,8 @@ class TestDtypes:
 
         pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -158,9 +156,8 @@ class TestDtypes:
 
         pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -183,9 +180,8 @@ class TestDtypes:
 
         pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -208,8 +204,7 @@ class TestDtypes:
 
         pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )

--- a/test/unit_tests/test_layers.py
+++ b/test/unit_tests/test_layers.py
@@ -11,11 +11,12 @@ class TestLayers:
     def setup_class(self):
         torch.manual_seed(5)
 
-        self.H = 224
-        self.W = 224
+        self.Cin = 3
+        self.Hin = 224
+        self.Win = 224
         self.BATCH_SIZE = 4
 
-        self.IMAGE = torch.rand((self.BATCH_SIZE, 3, self.H, self.W))
+        self.IMAGE = torch.rand((self.BATCH_SIZE, self.Cin, self.Hin, self.Win))
 
         self.USE_GPU = False
 
@@ -36,8 +37,6 @@ class TestLayers:
 
         p = fault_injection(
             self.model,
-            self.H,
-            self.W,
             self.BATCH_SIZE,
             layer_types=[torch.nn.Conv2d],
             use_cuda=self.USE_GPU,
@@ -57,8 +56,6 @@ class TestLayers:
     def test_single_linear_layer(self):
         p = fault_injection(
             self.model,
-            self.H,
-            self.W,
             self.BATCH_SIZE,
             layer_types=[torch.nn.Linear],
             use_cuda=self.USE_GPU,
@@ -71,8 +68,6 @@ class TestLayers:
     def test_single_linear_neuron_inj(self):
         p = fault_injection(
             self.model,
-            self.H,
-            self.W,
             self.BATCH_SIZE,
             layer_types=[torch.nn.Linear],
             use_cuda=self.USE_GPU,
@@ -91,8 +86,6 @@ class TestLayers:
     def test_combo_layers(self):
         p = fault_injection(
             self.model,
-            self.H,
-            self.W,
             self.BATCH_SIZE,
             layer_types=[torch.nn.Conv2d, torch.nn.Linear],
             # layer_types=[torch.nn.Conv2d],

--- a/test/unit_tests/test_neuron_errormodels.py
+++ b/test/unit_tests/test_neuron_errormodels.py
@@ -25,6 +25,7 @@ class TestNeuronErrorModels:
 
         self.BATCH_SIZE = 4
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = False
 
@@ -41,9 +42,8 @@ class TestNeuronErrorModels:
 
         self.p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -172,6 +172,7 @@ class TestNeuronErrorModelsFunc:
 
         self.BATCH_SIZE = 4
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = False
 
@@ -188,9 +189,8 @@ class TestNeuronErrorModelsFunc:
 
         self.p = single_bit_flip_func(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
             bits=8,
         )

--- a/test/unit_tests/test_neuron_fi.py
+++ b/test/unit_tests/test_neuron_fi.py
@@ -15,6 +15,7 @@ class TestNeuronFIgpu:
 
         self.BATCH_SIZE = 1
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = True
 
@@ -34,9 +35,8 @@ class TestNeuronFIgpu:
 
         self.p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -99,6 +99,7 @@ class TestNeuronFIcpu:
 
         self.BATCH_SIZE = 1
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = False
 
@@ -115,9 +116,8 @@ class TestNeuronFIcpu:
 
         self.p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -177,6 +177,7 @@ class TestNeuronFIgpuBatch:
 
         self.BATCH_SIZE = 4
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = True
 
@@ -196,9 +197,8 @@ class TestNeuronFIgpuBatch:
 
         self.p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 
@@ -265,6 +265,7 @@ class TestNeuronFIcpuBatch:
 
         self.BATCH_SIZE = 4
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = False
 
@@ -281,9 +282,8 @@ class TestNeuronFIcpuBatch:
 
         self.p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 

--- a/test/unit_tests/test_weight_errormodels.py
+++ b/test/unit_tests/test_weight_errormodels.py
@@ -19,6 +19,7 @@ class TestWeightErrorModels:
 
         self.BATCH_SIZE = 4
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = False
 
@@ -35,9 +36,8 @@ class TestWeightErrorModels:
 
         self.p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 

--- a/test/unit_tests/test_weight_fi.py
+++ b/test/unit_tests/test_weight_fi.py
@@ -14,6 +14,7 @@ class TestWeightFIcpu:
 
         self.BATCH_SIZE = 1
         self.WORKERS = 1
+        self.channels = 3
         self.img_size = 32
         self.USE_GPU = False
 
@@ -30,9 +31,8 @@ class TestWeightFIcpu:
 
         self.p = pfi_core(
             self.model,
-            self.img_size,
-            self.img_size,
             self.BATCH_SIZE,
+            input_shape=[self.channels, self.img_size, self.img_size],
             use_cuda=self.USE_GPU,
         )
 


### PR DESCRIPTION
- Reorg variables based on which are persistent versus resettable
- API change: input shape is requested during init. Default value of [3,224,224] assumes ImageNet-based input.
- NOTE: this [simplified](https://github.com/pytorchfi/pytorchfi/blob/f40014a5655cc91367e67d185badad15b86b6ea2/pytorchfi/core.py#L48) syntax requires Python version >=3.5.0 according to [this](https://stackoverflow.com/questions/30738275/unpack-list-into-middle-of-a-tuple).
- Regarding the previous note: we use a list() instead of a tuple() because you can't have a tuple with just one value.
- Add profiling info, inspired by [pytorch-summary](https://github.com/sksq96/pytorch-summary).