### PR TITLE
Fix bugs for doesn't work on resnet

### DIFF
--- a/pytorchfi/core.py
+++ b/pytorchfi/core.py
@@ -168,7 +168,7 @@ class fault_injection:
 
         current_layer = 0
         for name, param in self.corrupted_model.named_parameters():
-            if "weight" in name and "features" in name:
+            if "weight" in name and ( "features" or 'conv' in name):
                 if current_layer == corrupt_layer:
                     corrupt_idx = (
                         tuple(corrupt_idx)


### PR DESCRIPTION
# Fix bugs for doesn't work on resnet

 For example: Closes #75 .

- [x] Change : add an option for resnet
```python
if "weight" in name and "features" or  in name: 
to
if "weight" in name and ( "features" or 'conv' in name): 
```