### PR TITLE
add weight error model: multi_error

### DIFF
--- a/pytorchfi/weight_error_models.py
+++ b/pytorchfi/weight_error_models.py
@@ -54,3 +54,29 @@ def zero_func_rand_weight(pfi: core.FaultInjection):
 def _zero_rand_weight(data, location):
     new_data = data[location] * 0
     return new_data
+
+
+def multi_weight_inj(pfi, sdc_p=1e-5, function=_zero_rand_weight):
+    corrupt_idx = [[], [], [], [], []]
+    for layer_idx in range(pfi.get_total_layers()):
+        shape = list(pfi.get_weights_size(layer_idx))
+        dim_len = len(shape)
+        shape.extend([1 for i in range(4 - len(shape))])
+        for k in range(shape[0]):
+            for dim1 in range(shape[1]):
+                for dim2 in range(shape[2]):
+                    for dim3 in range(shape[3]):
+                        if random.random() < sdc_p:
+                            idx = [layer_idx, k, dim1, dim2, dim3]
+                            for i in range(dim_len + 1):
+                                corrupt_idx[i].append(idx[i])
+                            for i in range(dim_len + 1, 5):
+                                corrupt_idx[i].append(None)
+    return pfi.declare_weight_fault_injection(
+        layer_num=corrupt_idx[0],
+        k=corrupt_idx[1],
+        dim1=corrupt_idx[2],
+        dim2=corrupt_idx[3],
+        dim3=corrupt_idx[4],
+        function=function,
+    )

--- a/test/test_weight_error_models.py
+++ b/test/test_weight_error_models.py
@@ -7,6 +7,7 @@ from pytorchfi.weight_error_models import (
     random_weight_inj,
     random_weight_location,
     zero_func_rand_weight,
+    multi_weight_inj,
 )
 
 from .util_test import CIFAR10_set_up_custom
@@ -83,3 +84,12 @@ class TestWeightErrorModels:
             corrupt_output = corrupt_model(self.images)
 
         assert not torch.all(corrupt_output.eq(self.golden_output))
+
+    def test_multi_weight_inj(self):
+        random.seed(1)
+        corrupt_model = multi_weight_inj(self.p)
+        corrupt_model.eval()
+        with torch.no_grad():
+            corrupt_output = corrupt_model(self.images)
+        if torch.all(corrupt_output.eq(self.golden_output)):
+            raise AssertionError


### PR DESCRIPTION
Hi, I add a new useful weight error model multi_error_inj
The effect of corruption was defined by the user's function
- [x] Change : multi_error_inj
give every weight an SDC probability, and generate a random number in [0,1).
If a random number < SDC probability, then we inject a weight error on this position
- [x] Change : test for multi_error_inj
In order to better maintain this project in the future, I add a unit_test and all tests passed
All code was formatted by black